### PR TITLE
Added Modification to the RichText Widget

### DIFF
--- a/example/lib/src/screens/rich_text_plus_screen.dart
+++ b/example/lib/src/screens/rich_text_plus_screen.dart
@@ -34,36 +34,44 @@ class RichTextPlusScreen extends StatelessWidget {
 
   Widget _buildExample() {
     return RichTextPlus(
+      fontSize: 30,
       texts: [
         TextPlus(
           'Flutter ',
           color: Colors.black,
           fontWeight: FontWeight.normal,
-          fontSize: 30,
         ),
         TextPlus(
           'Plus ',
           color: Colors.red,
           fontWeight: FontWeight.bold,
-          fontSize: 30,
         ),
         TextPlus(
           '!',
           color: Colors.blue,
           fontWeight: FontWeight.bold,
-          fontSize: 30,
         ),
         TextPlus(
           '!',
           color: Colors.green,
           fontWeight: FontWeight.bold,
-          fontSize: 30,
         ),
         TextPlus(
           '!',
           color: Colors.orange,
           fontWeight: FontWeight.bold,
-          fontSize: 30,
+        ),
+        TextPlus(
+          '--->>>',
+          color: Colors.orange,
+          fontWeight: FontWeight.bold,
+          textDecorationPlus: TextDecorationPlus(
+            textDecoration: TextDecoration.underline,
+            color: Colors.orange,
+          ),
+          onTap: (() {
+            snackBarPlus.show(child: TextPlus("Flutter Plus is Awesome"));
+          }),
         ),
       ],
     );

--- a/lib/src/widgets/src/rich_text_plus.dart
+++ b/lib/src/widgets/src/rich_text_plus.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -27,6 +28,11 @@ class RichTextPlus extends StatelessWidget {
   final bool? softWrap;
   final TextAlign? textAlign;
 
+  // These are applied as the base style for all children texts.
+  final Color? color;
+  final FontWeight? fontWeight;
+  final double? fontSize;
+
   RichTextPlus({
     Key? key,
     this.maxLines,
@@ -37,6 +43,9 @@ class RichTextPlus extends StatelessWidget {
     this.overflow,
     this.softWrap = true,
     this.textAlign,
+    this.color,
+    this.fontWeight,
+    this.fontSize,
     // this.mainTextStyleX,
   }) : super(key: key);
 
@@ -67,12 +76,18 @@ class RichTextPlus extends StatelessWidget {
       textAlign: textAlign ?? TextAlign.start,
       text: TextSpan(
         text: '',
+        style: TextStyle(
+          color: color,
+          fontSize: fontSize,
+          fontWeight: fontWeight,
+        ),
         children: texts!
             .map(
               (richTextPlus) => TextSpan(
-                text: richTextPlus.text,
-                style: richTextPlus.textStyle,
-              ),
+                  text: richTextPlus.text,
+                  style: richTextPlus.textStyle,
+                  recognizer: TapGestureRecognizer()
+                    ..onTap = richTextPlus.onTap),
             )
             .toList(),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.17.0
+  intl: ^0.19.0
   diacritic: ^0.1.3
   shared_preferences: ^2.0.6
   path: ^1.8.0


### PR DESCRIPTION
Added the following: 

- The user can define the base text-style for the rich text that can be applied to all the TextPlus children 
- The user can tap the TextPlus element on which an onTap gesture is added. 
